### PR TITLE
Add GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build AuroraShade
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: Build AuroraShade
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Build
+        run: msbuild /p:Configuration=Release /p:Platform=64-bit ./ReShade.sln
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: AuroraShade
+          path: ./bin/x64/Release/ReShade64.dll


### PR DESCRIPTION
Hey ma, look what I can do that I couldn't with GShade!

---

This pull request adds a GitHub Action for building the source on a trustable platform (GitHub Actions workers). Assuming you can trust GitHub (because no GitHub employee is gonna backdoor their CI systems to spite a ReShade fork, right?), this means that the built artifact you distribute to users 100% matches the source code - one of the big bonuses of open source. If you do not use a system like this, users cannot verify that the .dll running on their computer matches the source code. It does not automatically do releases - you are expected to download the .dll from the artifacts and then upload it to the Releases tab.

Overall, I think forking ReShade is *probably* not what the community needs, but in any case it never hurts to have a fork with more features ~~that's open source~~. I wish you well on your project!

(By the way, can you set the default branch on GitHub to cn2-dev? I got a little confused looking for the right one.)